### PR TITLE
Delay downloading the images which are not on the screen 📷 

### DIFF
--- a/pages/gallery.js
+++ b/pages/gallery.js
@@ -867,7 +867,7 @@ export default function Gallery() {
             {gallery.filenames.map(filename => {
               const src = `/photos/${filename}`
               return (               
-                <div><img src={src} alt="Sea Mist" /></div>
+                <div><img src={src} alt="Sea Mist" loading="lazy" /></div>
               )
             })}
           </div>


### PR DESCRIPTION
The photo diary is great! 🛥️ 

I noticed that a bunch of the images failed to load for me and that was because my browser timed-out when downloading them. I believe it timed-out because it was trying to download too many images at the same time. Adding the loading=lazy attribute to the images should solve this issue 👍 

This should help speed up the loading of the site and also save bandwidth for people who don't scroll all the way to the last photo in the gallery

<details><summary>Lighthouse report before:</summary><img src=https://user-images.githubusercontent.com/1569131/123777266-f080da80-d8c7-11eb-8c8e-55b1f91f4c36.png></details>


<details><summary>Lighthouse report after:</summary><img src=https://user-images.githubusercontent.com/1569131/123776439-325d5100-d8c7-11eb-9547-a93686925832.png></details>
